### PR TITLE
Fix blis build errors due to unused functions

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,8 +4,8 @@ services:
     runtime: python
     buildCommand: |
       apt-get update && \
-      apt-get install -y build-essential gcc libblas-dev liblapack-dev && \
-      pip install -r requirements.txt
+      apt-get install -y build-essential gcc g++ libblas-dev liblapack-dev libopenblas-dev && \
+      pip install --no-cache-dir --prefer-binary -r requirements.txt
     startCommand: python app.py
     envVars:
       - key: TRANSFORMERS_CACHE

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ google-auth
 google-auth-oauthlib
 torch
 transformers
-spacy==3.6.1
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.6.0/en_core_web_sm-3.6.0.tar.gz
+blis==0.7.9
+spacy==3.7.2
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.0/en_core_web_sm-3.7.0.tar.gz


### PR DESCRIPTION
Fix `blis` compilation error during deployment.

The `blis` package, a dependency of `spacy`, was failing to build from source, causing deployment failures. This PR addresses the issue by ensuring pip prefers pre-compiled `blis` wheels, adding necessary build dependencies, and updating `spacy` to a version with better wheel support.

---
<a href="https://cursor.com/background-agent?bcId=bc-329fd488-9ca6-43d9-a880-91712acf7c46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-329fd488-9ca6-43d9-a880-91712acf7c46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

